### PR TITLE
Lightweight image

### DIFF
--- a/build
+++ b/build
@@ -24,6 +24,7 @@ fi
 
 echo "Installing dependencies..."
 sudo apt-get update
+sudo apt-get clean
 sudo apt-get install -y python-pip git libi2c-dev python-serial python-rpi.gpio i2c-tools python-smbus avahi-daemon
 cd ~
 sudo pip install flask
@@ -42,6 +43,9 @@ sudo dpkg -i rabbitmq-server_3.2.2-1_all.deb
 sudo apt-get -f -y install
 sudo rabbitmq-plugins enable rabbitmq_web_stomp
 sudo rabbitmqctl set_policy TTL ".*" '{"message-ttl":3000}' --apply-to queues
+sudo apt-get clean
+sudo apt-get upgrade
+sudo apt-get clean #reduces memory footprint from unused dependencies. (keeps image ~2.2GB)
 
 #install daemon tools
 sudo mkdir -p /package
@@ -53,10 +57,11 @@ tar -xpf daemontools-0.76.tar.gz
 rm -f daemontools-0.76.tar.gz
 cd admin/daemontools-0.76
 sudo ed ./src/conf-cc
-#if install fails:
+#if install fails, which it does on coder out of the box:
 1s/$/ -include errno.h/
 w
 q
+#install:
 sudo package/install
 
 

--- a/build
+++ b/build
@@ -88,6 +88,9 @@ if [[ -f /home/coder/coder-dist/coder-base/server.js ]]; then
   sudo a2dissite default
   sudo a2ensite blockly_ws.conf
   sudo apt-get install -y samba #for windows dns lookup
+
+  #not for automated scripting, but the server.js needs to be poked at a little bit
+  #in order for the routing to work correctly
 fi
 
 cd ~

--- a/build
+++ b/build
@@ -26,7 +26,6 @@ echo "Installing dependencies..."
 sudo apt-get update
 sudo apt-get install -y python-pip git libi2c-dev python-serial python-rpi.gpio i2c-tools python-smbus avahi-daemon
 cd ~
-sudo apt-get install -y samba #for windows dns lookup
 sudo pip install flask
 sudo pip install tornado
 sudo pip install jsonpickle
@@ -40,6 +39,7 @@ sudo pip install flask-bcrypt
 sudo pip install requests
 wget http://www.rabbitmq.com/releases/rabbitmq-server/v3.2.2/rabbitmq-server_3.2.2-1_all.deb
 sudo dpkg -i rabbitmq-server_3.2.2-1_all.deb
+sudo apt-get -f -y install
 sudo rabbitmq-plugins enable rabbitmq_web_stomp
 sudo rabbitmqctl set_policy TTL ".*" '{"message-ttl":3000}' --apply-to queues
 
@@ -52,15 +52,18 @@ wget http://cr.yp.to/daemontools/daemontools-0.76.tar.gz
 tar -xpf daemontools-0.76.tar.gz
 rm -f daemontools-0.76.tar.gz
 cd admin/daemontools-0.76
-package/install
-ed ./src/conf-cc
-ls/$/ -include errno.h/
-wq
+sudo ed ./src/conf-cc
+#if install fails:
+1s/$/ -include errno.h/
+w
+q
+sudo package/install
 
-sudo apt-get install csh
+
+sudo apt-get install -y csh
 sudo csh -cf '/command/svscanboot &'
 
-sudo sed -i "1 a\csh -cf '/command/svscanboot &'" /etc/rc.local
+#sudo sed -i "1 a\csh -cf '/command/svscanboot &'" /etc/rc.local
 sudo chmod +x /etc/rc.local
 
 sudo mkdir /service/hd
@@ -80,9 +83,11 @@ if [[ -f /home/coder/coder-dist/coder-base/server.js ]]; then
   sudo a2enmod proxy_http
   sudo a2enmod ssl
   #make wsgi and httpd conf
-  sudo cp /home/pi/blockytalky/build.d/blockly_ws.wsgi /etc/apache2/blockly_ws.wsgi
-  sudo cp /home/pi/blockytalky/build.d/blockly_ws.conf /etc/apache2/sites-available/blockly_ws.conf
+  sudo cp /home/pi/blockytalky/build.d/blockly_ws.wsgi /etc/apache2/
+  sudo cp /home/pi/blockytalky/build.d/blockly_ws.conf /etc/apache2/sites-available/
+  sudo a2dissite default
   sudo a2ensite blockly_ws.conf
+  sudo apt-get install -y samba #for windows dns lookup
 fi
 
 cd ~
@@ -128,7 +133,8 @@ fi
 if [ "$host" == "y" ] || [ "$host" == "Y" ]; then
     sudo echo $hostname > /etc/hostname
     sudo sed -i -e "s/raspberrypi/$hostname/g" /etc/hosts
-    sudo echo $hostname > /etc/hos
+    sudo sed -i -e "s/coder/$hostname/g" /etc/hosts
+    sudo export HOSTNAME=$hostname
 fi
 
 echo "BlockyTalky installed! Restart required. System restart in 5 seconds (press CTRL-C to cancel)"

--- a/build
+++ b/build
@@ -33,6 +33,10 @@ sudo pip install pyttsx
 sudo pip install pyOSC
 sudo pip install websocket-client
 sudo pip install pika
+sudo apt-get install -y python-dev
+sudo apt-get install -y libffi-dev
+sudo pip install flask-bcrypt
+sudo pip install requests
 wget http://www.rabbitmq.com/releases/rabbitmq-server/v3.2.2/rabbitmq-server_3.2.2-1_all.deb
 sudo dpkg -i rabbitmq-server_3.2.2-1_all.deb
 sudo rabbitmq-plugins enable rabbitmq_web_stomp
@@ -48,14 +52,18 @@ cd wiringPi
 echo "Setting up serial pins..."
 gpio load i2c 10
 sudo echo init_uart_clock=32000000 >> /boot/config.txt
-sudo echo '#for real-time kernel' >> /boot/config.txt
-sudo echo 'disable_splash=1' >> /boot/config.txt
-sudo echo 'kernel=kernel-rt.img' >> /boot/config.txt
 sudo sed -i 's/arm_freq=[0-9]*/arm_freq=900/g' /boot/config.txt
 sudo sed -i -e 's,T0:23:respawn:/sbin/getty -L ttyAMA0 115200 vt100,#T0:23:respawn:/sbin/getty -L ttyAMA0 115200 t100,' /etc/inittab
 sudo sed -i -e 's/console=ttyAMA0,115200 kgdboc=ttyAMA0,115200//g' /boot/cmdline.txt
 sudo sed -i -e 's,blacklist i2c-bcm2708,#blacklist i2c-bcm2708,' /etc/modprobe.d/raspi-blacklist.conf
 sudo echo i2c-dev >> /etc/modules
+
+
+#  sudo echo '#for real-time kernel' >> /boot/config.txt
+#  sudo echo 'disable_splash=1' >> /boot/config.txt
+#  sudo echo 'kernel=kernel-rt.img' >> /boot/config.txt
+#  sudo echo 'force_turbo=1' >> /boot/config.txt
+
 
 echo "Installing customizations..."
 sudo sed -i -e 's/XKBLAYOUT="gb"/XKBLAYOUT="us"/g' /etc/default/keyboard
@@ -79,6 +87,7 @@ fi
 if [ "$host" == "y" ] || [ "$host" == "Y" ]; then
     sudo echo $hostname > /etc/hostname
     sudo sed -i -e "s/raspberrypi/$hostname/g" /etc/hosts
+    sudo echo $hostname > /etc/hos
 fi
 
 echo "BlockyTalky installed! Restart required. System restart in 5 seconds (press CTRL-C to cancel)"

--- a/build
+++ b/build
@@ -26,6 +26,7 @@ echo "Installing dependencies..."
 sudo apt-get update
 sudo apt-get install -y python-pip git libi2c-dev python-serial python-rpi.gpio i2c-tools python-smbus avahi-daemon
 cd ~
+sudo apt-get install -y samba #for windows dns lookup
 sudo pip install flask
 sudo pip install tornado
 sudo pip install jsonpickle
@@ -42,7 +43,47 @@ sudo dpkg -i rabbitmq-server_3.2.2-1_all.deb
 sudo rabbitmq-plugins enable rabbitmq_web_stomp
 sudo rabbitmqctl set_policy TTL ".*" '{"message-ttl":3000}' --apply-to queues
 
+#install daemon tools
+sudo mkdir -p /package
+sudo chmod 755 /package
+cd /package
 
+wget http://cr.yp.to/daemontools/daemontools-0.76.tar.gz
+tar -xpf daemontools-0.76.tar.gz
+rm -f daemontools-0.76.tar.gz
+cd admin/daemontools-0.76
+package/install
+ed ./src/conf-cc
+ls/$/ -include errno.h/
+wq
+
+sudo apt-get install csh
+sudo csh -cf '/command/svscanboot &'
+
+sudo sed -i "1 a\csh -cf '/command/svscanboot &'" /etc/rc.local
+sudo chmod +x /etc/rc.local
+
+sudo mkdir /service/hd
+sudo cp /home/pi/blockytalky/build.d/run /service/hd
+
+echo 'wins server =wlan0:0.0.0.0' > /etc/samba/dhcp.conf
+if [[ -f /home/coder/coder-dist/coder-base/server.js ]]; then
+  sudo cp /home/coder/coder-dist/coder-base/server.js /home/coder/coder-dist/coder-base/server.js.bkup
+  sudo cp /home/coder/coder-dist/coder-base/localserver.js /home/coder/coder-dist/coder-base/server.js
+  sudo /home/coder/coder-dist/coder-base/config.js.localhost /home/coder/coder-dist/coder-base/config.js
+  #this runs coder on :8080 for our proxy config later
+  #virtual host for blockly+coder
+  sudo apt-get install -y libapache2-mod-wsgi
+  sudo a2enmod wsgi
+  sudo a2enmod rewrite
+  sudo a2enmod proxy
+  sudo a2enmod proxy_http
+  sudo a2enmod ssl
+  #make wsgi and httpd conf
+  sudo cp /home/pi/blockytalky/build.d/blockly_ws.wsgi /etc/apache2/blockly_ws.wsgi
+  sudo cp /home/pi/blockytalky/build.d/blockly_ws.conf /etc/apache2/sites-available/blockly_ws.conf
+  sudo a2ensite blockly_ws.conf
+fi
 
 cd ~
 git clone git://git.drogon.net/wiringPi

--- a/build.d/blockly_ws.conf
+++ b/build.d/blockly_ws.conf
@@ -1,0 +1,31 @@
+<VirtualHost *:80>
+	ServerName localhost
+	ServerAdmin lpc@cs.tufts.edu
+	WSGIScriptAlias / /home/pi/blockly_ws.wsgi
+	<Directory /home/pi/blockytalky/backend>
+		Order allow,deny
+		Allow from all
+	</Directory>
+	RewriteEngine On
+	RewriteCond %{HTTPS} !=on
+       RewriteRule ^/?app/(.*) https://%{SERVER_NAME}/app/$1 [R,L]
+	
+</VirtualHost>
+<VirtualHost *:443>
+	ServerName coder.local
+	SSLEngine on
+	SSLCertificateFile 	/home/coder/coder-dist/coder-base/certs/server.cert
+	SSLCertificateKeyFile 	/home/coder/coder-dist/coder-base/certs/server.key
+	ProxyRequests off
+	<Proxy *>
+		Order deny,allow
+		Allow from all
+	</Proxy>
+
+	<Location />
+		ProxyPass http://localhost:8080/ retry=0 acquire=3000 timeout=600 Keepalive=On
+		ProxyPassReverse http://localhost:8080/
+	</Location>
+	RewriteEngine On
+	RewriteRule ^/$ http://%{SERVER_NAME}/ [R,L]
+</VirtualHost>

--- a/build.d/blockly_ws.conf
+++ b/build.d/blockly_ws.conf
@@ -1,21 +1,22 @@
 <VirtualHost *:80>
 	ServerName localhost
 	ServerAdmin lpc@cs.tufts.edu
-	WSGIScriptAlias / /home/pi/blockly_ws.wsgi
+	WSGIScriptAlias / /etc/apache2/blockly_ws.wsgi
 	<Directory /home/pi/blockytalky/backend>
 		Order allow,deny
 		Allow from all
 	</Directory>
 	RewriteEngine On
 	RewriteCond %{HTTPS} !=on
-       RewriteRule ^/?app/(.*) https://%{SERVER_NAME}/app/$1 [R,L]
-	
+        RewriteRule ^/?app/(.*) https://%{SERVER_NAME}/app/$1 [R,L]
 </VirtualHost>
 <VirtualHost *:443>
-	ServerName coder.local
+	ServerName localhost
 	SSLEngine on
 	SSLCertificateFile 	/home/coder/coder-dist/coder-base/certs/server.cert
 	SSLCertificateKeyFile 	/home/coder/coder-dist/coder-base/certs/server.key
+	RewriteEngine On
+
 	ProxyRequests off
 	<Proxy *>
 		Order deny,allow
@@ -26,6 +27,7 @@
 		ProxyPass http://localhost:8080/ retry=0 acquire=3000 timeout=600 Keepalive=On
 		ProxyPassReverse http://localhost:8080/
 	</Location>
-	RewriteEngine On
+
 	RewriteRule ^/$ http://%{SERVER_NAME}/ [R,L]
+	
 </VirtualHost>

--- a/build.d/blockly_ws.wsgi
+++ b/build.d/blockly_ws.wsgi
@@ -1,0 +1,4 @@
+import sys
+sys.path.insert(0,'/home/pi/blockytalky/backend/')
+
+from blockly_webserver import app as application

--- a/build.d/run
+++ b/build.d/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Starting Hardware_daemon.py"
+exec "python /home/pi/blockytalky/backend/hardware_daemon.py"

--- a/change-hostname.sh
+++ b/change-hostname.sh
@@ -15,6 +15,7 @@ sudo sed -i -e "s/\"device\_name\": \"[a-zA-Z0-9]*\",/\"device\_name\": \"$nhost
 sudo sed -i -e "s/BT-$chost/BT-$nhost/g" /etc/wpa_supplicant/wpa_supplicant.conf
 sudo sed -i -e "s/sentinel/$nhost/g" /etc/wpa_supplicant/wpa_supplicant.conf
 
+sudo sed -i -e "s/$chost/$nhost/g" /home/coder/coder-dist/coder-base/server.js
 echo "Hostname change complete. Restarting your BlockyTalky unit. To cancel, press CTRL-C"
 echo "5..."
 sleep 1


### PR DESCRIPTION
Updated the build script so that if someone takes a stock Raspbian or Coder image, they can just run ./build and it sets everything up correctly:
- Manages hardware_daemon.py with daemontools
- installs all the python deps
- uses apache to manage both coder (node.js) and blockly_webserver (flask) for port resolution

Also it nicely serves as a contract of everything blocky talky needs on the os to run safely.

code changes are compatible with current builds (so this is only a patch release candidate).
